### PR TITLE
Fixed 'Only one default export allowed per module' errors.

### DIFF
--- a/client/components/side-menu/item.jsx
+++ b/client/components/side-menu/item.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router';
 
 let s = getStyle();
 
-export default class Item extends React.Component {
+export class Item extends React.Component {
   constructor(props) {
     super(props);
     this.handleHover = this.handleHover.bind(this);

--- a/client/components/side-menu/side-menu.jsx
+++ b/client/components/side-menu/side-menu.jsx
@@ -11,7 +11,7 @@ import { logout } from 'auth/login.js';
 
 let s = getStyle();
 
-export default class SideMenu extends React.Component {
+export class SideMenu extends React.Component {
   constructor(props) {
     super(props);
   }

--- a/client/containers/index/index.jsx
+++ b/client/containers/index/index.jsx
@@ -14,7 +14,7 @@ import SideMenu from 'side-menu/side-menu.jsx';
 let s = getStyle();
 let slider;
 
-export default class Index extends React.Component {
+export class Index extends React.Component {
   constructor(props) {
     super(props);
   }


### PR DESCRIPTION
Hello @PBRT ,

When I tried out ReactToGo starter kit after running `npm run start` command and browse the sample app, i got error message as in this following screenshot:

![image](https://cloud.githubusercontent.com/assets/18456618/19613070/dc2e1ae8-981c-11e6-9783-bf6cd6e22f48.png)

Then, I changed several files which cause this error. Could you have a look at them and merge them to the master branch if you have no concerns regarding with the fixes ? 
Many thanks in advance.

Cheers.
